### PR TITLE
Update starfinder reload to account for weapon usage when reloading

### DIFF
--- a/campaign/scripts/ammo_sfrpg_reload.lua
+++ b/campaign/scripts/ammo_sfrpg_reload.lua
@@ -3,20 +3,23 @@
 -- attribution and copyright information.
 --
 
-local function getNodeFromShortcut(nodeParent, shortcutField)
-	local _,sShortcut = DB.getValue(nodeParent, shortcutField, '');
+local function getWeaponUsage(nodeWeapon)
+	local _,sShortcut = DB.getValue(nodeWeapon, 'shortcut', '');
 	if sShortcut and sShortcut ~= '' then
-		return DB.findNode(sShortcut)
+		local nodeLinkedWeapon = DB.findNode(sShortcut)
+		if nodeLinkedWeapon then
+			return DB.getValue(nodeLinkedWeapon, 'usage', 1)
+		end
 	end
+	return 1
 end
 
 local function reduceItemCount(nodeWeapon, nAmmo)
-	local nodeAmmo = AmmunitionManager.getAmmoNode(nodeWeapon);
-	local nodeLinkedWeapon = getNodeFromShortcut(nodeWeapon, "shortcut")
+	local nodeAmmo = AmmunitionManager.getAmmoNode(nodeWeapon)
 	if nodeAmmo then
 		local nCount = DB.getValue(nodeAmmo, "count", 0)
 		if (nAmmo > 0) and (nCount > 0) then
-			local nUsage = DB.getValue(nodeLinkedWeapon, "usage", 0)
+			local nUsage = getWeaponUsage(nodeWeapon)
 			local nReload = nCount - nAmmo * nUsage
 			if nReload > 0 then
 				DB.setValue(nodeWeapon, 'ammo', 'number', 0)


### PR DESCRIPTION
Starfinder seems to take `{weapon max capacity} / {weapon shot usage}` to give the ammo on the actions tab

When performing a reload the required ammo should be `{ammo to replenish} * {weapon shot usage}`

This doesn't quite account for starfinder's use of Magazines & Batteries being individual items containing consumables (similar to a Quiver of arrows or Wand with charges in Pathfinder. That said its a decent stopgap for now