### PR TITLE
SFRPG: Allow ammo pips to be edited when linked

### DIFF
--- a/campaign/scripts/sfrpg_crosslink_ammocounter.lua
+++ b/campaign/scripts/sfrpg_crosslink_ammocounter.lua
@@ -49,13 +49,10 @@ function setLink(dbnode)
     if dbnode then
         sLink = dbnode.getPath()
 
-        setReadOnly(true)
-
         DB.addHandler(sLink, 'onUpdate', onLinkUpdated)
 
         onLinkUpdated()
     else
-        setReadOnly(false)
         setCurrentValue(getMaxValue())
     end
 end

--- a/common/scripts/number_crosslink_unlink.lua
+++ b/common/scripts/number_crosslink_unlink.lua
@@ -79,5 +79,8 @@ function setLink(dbnode)
 		onLinkUpdated();
 	else
 		setReadOnly(false)
+		if User.getRulesetName() == 'SFRPG' then
+			setValue(0)
+		end
 	end
 end


### PR DESCRIPTION
Ammo pips were being set to read only, easy change to just remove the read only switches based on linking.

Also re-add the zeroing of ammo on unloading ammo.