### PR TITLE
SFRPG: don't use the ammotracker for starfinder

### DIFF
--- a/scripts/manager_ammunition.lua
+++ b/scripts/manager_ammunition.lua
@@ -206,6 +206,8 @@ function onInit()
 		CharWeaponManager.decrementAmmo = noDecrementAmmo
 	end
 
-	onPostAttackResolve_old = ActionAttack.onPostAttackResolve
-	ActionAttack.onPostAttackResolve = onPostAttackResolve_new
+	if sRuleset ~= 'SFRPG' then -- SFRPG handled differently
+		onPostAttackResolve_old = ActionAttack.onPostAttackResolve
+		ActionAttack.onPostAttackResolve = onPostAttackResolve_new
+	end
 end


### PR DESCRIPTION
Starfinder handles its ammo consumption when attacks are generated. While consuming ammo after an attack is resolved is probably the better way even the base SFRPG ruleset consumes ammo at attack generation time.

For now I've added for the SFRPG ruleset to skip updating the `onPostAttackResolve` action.